### PR TITLE
Fixed typo in form name causing verification not to work.

### DIFF
--- a/website/verify.html
+++ b/website/verify.html
@@ -29,7 +29,7 @@ layout: default
       </div>
       <div class="card-body">
         <h5 class="card-subtitle mb-2">Verify Code</h4>
-          <form id="registrationForm">
+          <form id="verifyForm">
             <div class="form-group">
               <input type="email" id="emailInputVerify" class="form-control form-control-sm" placeholder="Email Address" pattern=".*" required>
               <input type="text" id="codeInputVerify" class="form-control form-control-sm" placeholder="Verification Code" pattern=".*"


### PR DESCRIPTION
The form element on the verify page was named registrationForm instead of verifyForm, which caused it to execute the wrong code when submitted, breaking the verification function.